### PR TITLE
fixing npm package for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "battery-level",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Get current battery level",
   "license": "MIT",
   "repository": "gillstrom/battery-level",
@@ -17,6 +17,7 @@
   },
   "bin": "cli.js",
   "files": [
+    "win.js",
     "cli.js",
     "index.js"
   ],


### PR DESCRIPTION
since `./win.js` is ignored by npm and thus not found locally
